### PR TITLE
#18 Limiter dashboard feedback Implementation, #14 debug fix

### DIFF
--- a/OverlayDDU.h
+++ b/OverlayDDU.h
@@ -278,7 +278,7 @@ class OverlayDDU : public Overlay
                     }
                 }
                 
-                if (!(ir_EngineWarnings.getInt() & irsdk_pitSpeedLimiter))
+                if ((ir_EngineWarnings.getInt() & irsdk_pitSpeedLimiter))
                 {
                     int frames = 60;
                     if (g_cfg.getBool("General", "performance_mode_30hz", false)) frames = 30;
@@ -297,7 +297,7 @@ class OverlayDDU : public Overlay
 
             // Gear & Speed
             {
-                if (!(ir_EngineWarnings.getInt() & irsdk_pitSpeedLimiter))
+                if ((ir_EngineWarnings.getInt() & irsdk_pitSpeedLimiter))
                 {
                     int frames = 60;
                     if (g_cfg.getBool("General", "performance_mode_30hz", false)) frames = 30;

--- a/OverlayDDU.h
+++ b/OverlayDDU.h
@@ -579,25 +579,32 @@ class OverlayDDU : public Overlay
                 const float rr = 100.0f * std::min(std::min( ir_RRwearL.getFloat(), ir_RRwearM.getFloat() ), ir_RRwearR.getFloat() );
 
                 // Left
-                if( ir_dpLTireChange.getFloat() )
-                    m_brush->SetColor( serviceCol );
-                else
-                    m_brush->SetColor( textCol );
-                swprintf( s, _countof(s), L"%d", (int)(lf+0.5f) );
-                m_text.render( m_renderTarget.Get(), s, m_textFormatSmall.Get(), m_boxTires.x0+20, m_boxTires.x0+m_boxTires.w/2, m_boxTires.y0+m_boxTires.h*1.0f/3.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_CENTER );
-                swprintf( s, _countof(s), L"%d", (int)(lr+0.5f) );
-                m_text.render( m_renderTarget.Get(), s, m_textFormatSmall.Get(), m_boxTires.x0+20, m_boxTires.x0+m_boxTires.w/2, m_boxTires.y0+m_boxTires.h*2.0f/3.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_CENTER );
+                if (ir_dpLTireChange.isValid())
+                {
+                    if (ir_dpLTireChange.getFloat())
+                        m_brush->SetColor(serviceCol);
+                    else
+                        m_brush->SetColor(textCol);
 
-                // Right
-                if( ir_dpRTireChange.getFloat() )
-                    m_brush->SetColor( serviceCol );
-                else
-                    m_brush->SetColor( textCol );
-                swprintf( s, _countof(s), L"%d", (int)(rf+0.5f) );
-                m_text.render( m_renderTarget.Get(), s, m_textFormatSmall.Get(), m_boxTires.x0+m_boxTires.w/2, m_boxTires.x1-20, m_boxTires.y0+m_boxTires.h*1.0f/3.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_CENTER );
-                swprintf( s, _countof(s), L"%d", (int)(rr+0.5f) );
-                m_text.render( m_renderTarget.Get(), s, m_textFormatSmall.Get(), m_boxTires.x0+m_boxTires.w/2, m_boxTires.x1-20, m_boxTires.y0+m_boxTires.h*2.0f/3.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_CENTER );
-                m_brush->SetColor( textCol );
+                        swprintf(s, _countof(s), L"%d", (int)(lf + 0.5f));
+                        m_text.render(m_renderTarget.Get(), s, m_textFormatSmall.Get(), m_boxTires.x0 + 20, m_boxTires.x0 + m_boxTires.w / 2, m_boxTires.y0 + m_boxTires.h * 1.0f / 3.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_CENTER);
+                        swprintf(s, _countof(s), L"%d", (int)(lr + 0.5f));
+                        m_text.render(m_renderTarget.Get(), s, m_textFormatSmall.Get(), m_boxTires.x0 + 20, m_boxTires.x0 + m_boxTires.w / 2, m_boxTires.y0 + m_boxTires.h * 2.0f / 3.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_CENTER);
+                }
+
+                if (ir_dpRTireChange.isValid())
+                {
+                    // Right
+                    if (ir_dpRTireChange.getFloat())
+                        m_brush->SetColor(serviceCol);
+                    else
+                        m_brush->SetColor(textCol);
+                    swprintf(s, _countof(s), L"%d", (int)(rf + 0.5f));
+                    m_text.render(m_renderTarget.Get(), s, m_textFormatSmall.Get(), m_boxTires.x0 + m_boxTires.w / 2, m_boxTires.x1 - 20, m_boxTires.y0 + m_boxTires.h * 1.0f / 3.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_CENTER);
+                    swprintf(s, _countof(s), L"%d", (int)(rr + 0.5f));
+                    m_text.render(m_renderTarget.Get(), s, m_textFormatSmall.Get(), m_boxTires.x0 + m_boxTires.w / 2, m_boxTires.x1 - 20, m_boxTires.y0 + m_boxTires.h * 2.0f / 3.0f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_CENTER);
+                    m_brush->SetColor(textCol);
+                }
                 
                 /* TODO: why doesn't iracing report 255 here in an AI session where we DO have unlimited tire sets??
 
@@ -659,9 +666,12 @@ class OverlayDDU : public Overlay
 
             // Brake bias
             {
-                const float bias = ir_dcBrakeBias.getFloat();
-                swprintf( s, _countof(s), L"%+3.1f", bias );
-                m_text.render( m_renderTarget.Get(), s, m_textFormat.Get(), m_boxBias.x0, m_boxBias.x1, m_boxBias.y0+m_boxBias.h*0.5f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_CENTER );
+                if (ir_dcBrakeBias.isValid())
+                {
+                    const float bias = ir_dcBrakeBias.getFloat();
+                    swprintf(s, _countof(s), L"%+3.1f", bias);
+                    m_text.render(m_renderTarget.Get(), s, m_textFormat.Get(), m_boxBias.x0, m_boxBias.x1, m_boxBias.y0 + m_boxBias.h * 0.5f, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_CENTER);
+                }
             }
 
             // Oil temp

--- a/OverlayDDU.h
+++ b/OverlayDDU.h
@@ -282,7 +282,7 @@ class OverlayDDU : public Overlay
                 {
                     int frames = 60;
                     if (g_cfg.getBool("General", "performance_mode_30hz", false)) frames = 30;
-                    if (m_rpmFlashTickCount <= frames / 4)  m_brush->SetColor(warnCol);
+                    if (((tickCount / 16) % (frames / 2)) <= frames / 4)  m_brush->SetColor(warnCol);
                     else m_brush->SetColor(outlineCol);
                     
                     for (int i = 0; i < 8; ++i)
@@ -290,18 +290,18 @@ class OverlayDDU : public Overlay
                         D2D1_ELLIPSE e = { float2(r2ax(0.5f - ww / 2 + (i + 0.5f) * ww / 8),r2ay(0.065f)), r2ax(0.007f), r2ax(0.007f) };
                         m_renderTarget->DrawEllipse(&e, m_brush.Get());
                     }
-                    m_rpmFlashTickCount++;
-                    if (m_rpmFlashTickCount > frames / 2) m_rpmFlashTickCount = 0;
                 }
             }
 
             // Gear & Speed
             {
+                //std::cout << tickCount / 16 << std::endl;
                 if ((ir_EngineWarnings.getInt() & irsdk_pitSpeedLimiter))
                 {
                     int frames = 60;
                     if (g_cfg.getBool("General", "performance_mode_30hz", false)) frames = 30;
-                    if (m_rpmFlashTickCount <= frames / 4)
+                    //std::cout << (tickCount % frames) << std::endl;
+                    if (((tickCount / 16) % (frames / 2)) <= frames / 4)
                     {
                         m_brush->SetColor(goodCol);
                         D2D1_RECT_F r = { m_boxGear.x0, m_boxGear.y0, m_boxGear.x1, m_boxGear.y1 };
@@ -813,7 +813,6 @@ class OverlayDDU : public Overlay
 
         int                 m_prevCurrentLap = 0;
         DWORD               m_lastLapChangeTickCount = 0;
-        DWORD               m_rpmFlashTickCount = 0;
 
         float               m_prevBestLapTime = 0;
 

--- a/OverlayDDU.h
+++ b/OverlayDDU.h
@@ -258,15 +258,15 @@ class OverlayDDU : public Overlay
                 const float rpmPct = (rpm-lo) / (hi-lo);
 
                 const float ww = 0.16f;
-                for( int i=0; i<8; ++i )
+                if (!(ir_EngineWarnings.getInt() & irsdk_pitSpeedLimiter))
                 {
-                    const float lightPct = i/8.0f;
-                    const float lightRpm = lo + (hi-lo) * lightPct;
-
-                    D2D1_ELLIPSE e = { float2(r2ax(0.5f-ww/2+(i+0.5f)*ww/8),r2ay(0.065f)), r2ax(0.007f), r2ax(0.007f) };
-
-                    if (!(ir_EngineWarnings.getInt() & irsdk_pitSpeedLimiter))
+                    for (int i = 0; i < 8; ++i)
                     {
+                        const float lightPct = i / 8.0f;
+                        const float lightRpm = lo + (hi - lo) * lightPct;
+
+                        D2D1_ELLIPSE e = { float2(r2ax(0.5f - ww / 2 + (i + 0.5f) * ww / 8),r2ay(0.065f)), r2ax(0.007f), r2ax(0.007f) };
+
                         if (rpmPct < lightPct) {
                             m_brush->SetColor(outlineCol);
                             m_renderTarget->DrawEllipse(&e, m_brush.Get());
@@ -281,24 +281,48 @@ class OverlayDDU : public Overlay
                             m_renderTarget->FillEllipse(&e, m_brush.Get());
                         }
                     }
+                }
+                else
+                {
+                    D2D1_ELLIPSE l0 = { float2(r2ax(0.5f - ww / 2 + (0 + 0.5f) * ww / 8),r2ay(0.065f)), r2ax(0.007f), r2ax(0.007f) };
+                    D2D1_ELLIPSE l1 = { float2(r2ax(0.5f - ww / 2 + (1 + 0.5f) * ww / 8),r2ay(0.065f)), r2ax(0.007f), r2ax(0.007f) };
+                    D2D1_ELLIPSE l2 = { float2(r2ax(0.5f - ww / 2 + (2 + 0.5f) * ww / 8),r2ay(0.065f)), r2ax(0.007f), r2ax(0.007f) };
+                    D2D1_ELLIPSE l3 = { float2(r2ax(0.5f - ww / 2 + (3 + 0.5f) * ww / 8),r2ay(0.065f)), r2ax(0.007f), r2ax(0.007f) };
+                    D2D1_ELLIPSE l4 = { float2(r2ax(0.5f - ww / 2 + (4 + 0.5f) * ww / 8),r2ay(0.065f)), r2ax(0.007f), r2ax(0.007f) };
+                    D2D1_ELLIPSE l5 = { float2(r2ax(0.5f - ww / 2 + (5 + 0.5f) * ww / 8),r2ay(0.065f)), r2ax(0.007f), r2ax(0.007f) };
+                    D2D1_ELLIPSE l6 = { float2(r2ax(0.5f - ww / 2 + (6 + 0.5f) * ww / 8),r2ay(0.065f)), r2ax(0.007f), r2ax(0.007f) };
+                    D2D1_ELLIPSE l7 = { float2(r2ax(0.5f - ww / 2 + (7 + 0.5f) * ww / 8),r2ay(0.065f)), r2ax(0.007f), r2ax(0.007f) };
+
+                    int frames = 60;
+                    if (g_cfg.getBool("General", "performance_mode_30hz", false)) frames = 30;
+
+                    if (m_rpmFlashTickCount <= frames / 2)
+                    {
+                        m_brush->SetColor(limiterCol);
+                        m_renderTarget->FillEllipse(&l0, m_brush.Get());
+                        m_renderTarget->FillEllipse(&l1, m_brush.Get());
+                        m_renderTarget->FillEllipse(&l2, m_brush.Get());
+                        m_renderTarget->FillEllipse(&l3, m_brush.Get());
+                        m_renderTarget->FillEllipse(&l4, m_brush.Get());
+                        m_renderTarget->FillEllipse(&l5, m_brush.Get());
+                        m_renderTarget->FillEllipse(&l6, m_brush.Get());
+                        m_renderTarget->FillEllipse(&l7, m_brush.Get());
+                        m_rpmFlashTickCount++;
+                    }
                     else
                     {
-                        int frames = 60;
-                        if (g_cfg.getBool("General", "performance_mode_30hz", false)) frames = 30;
-                        
-                        if (m_rpmFlashTickCount <= frames / 2)
-                        {
-                            m_brush->SetColor(limiterCol);
-                            m_rpmFlashTickCount++;
-                        }
-                        else
-                        {
-                            m_brush->SetColor(outlineCol);
-                            m_rpmFlashTickCount++;
-                        }
-                        if (m_rpmFlashTickCount > frames) m_rpmFlashTickCount = 0;
-                        m_renderTarget->DrawEllipse(&e, m_brush.Get());
+                        m_brush->SetColor(outlineCol);
+                        m_renderTarget->DrawEllipse(&l0, m_brush.Get());
+                        m_renderTarget->DrawEllipse(&l1, m_brush.Get());
+                        m_renderTarget->DrawEllipse(&l2, m_brush.Get());
+                        m_renderTarget->DrawEllipse(&l3, m_brush.Get());
+                        m_renderTarget->DrawEllipse(&l4, m_brush.Get());
+                        m_renderTarget->DrawEllipse(&l5, m_brush.Get());
+                        m_renderTarget->DrawEllipse(&l6, m_brush.Get());
+                        m_renderTarget->DrawEllipse(&l7, m_brush.Get());
+                        m_rpmFlashTickCount++;
                     }
+                    if (m_rpmFlashTickCount > frames) m_rpmFlashTickCount = 0;
                 }
             }
 

--- a/OverlayStandings.h
+++ b/OverlayStandings.h
@@ -363,16 +363,18 @@ protected:
             float trackTemp = ir_TrackTempCrew.getFloat();
             float airTemp   = ir_AirTemp.getFloat();
             char  tempUnit  = 'C';
+            int lapcount = ir_CarIdxLap.getInt(ir_session.driverCarIdx);
+            int totallaps = ir_SessionLapsTotal.getInt();
 
             if( imperial ) {
                 trackTemp = celsiusToFahrenheit( trackTemp );
                 airTemp   = celsiusToFahrenheit( airTemp );
                 tempUnit  = 'F';
             }
-
+          
             m_brush->SetColor(float4(1,1,1,0.4f));
             m_renderTarget->DrawLine( float2(0,ybottom),float2((float)m_width,ybottom),m_brush.Get() );
-            swprintf( s, _countof(s), L"SoF: %d      Track Temp: %.1f°%c      Air Temp: %.1f°%c      Setup: %s      Subsession: %d", ir_session.sof, trackTemp, tempUnit, airTemp, tempUnit, ir_session.isFixedSetup?L"fixed":L"open", ir_session.subsessionId );
+            swprintf( s, _countof(s), L"SoF: %d      Track Temp: %.1f°%c      Air Temp: %.1f°%c      Setup: %s      Subsession: %d      Lap: %d/%d", ir_session.sof, trackTemp, tempUnit, airTemp, tempUnit, ir_session.isFixedSetup?L"fixed":L"open", ir_session.subsessionId, lapcount, totallaps);
             y = m_height - (m_height-ybottom)/2;
             m_brush->SetColor( headerCol );
             m_text.render( m_renderTarget.Get(), s, m_textFormat.Get(), xoff, (float)m_width-2*xoff, y, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_CENTER );

--- a/OverlayStandings.h
+++ b/OverlayStandings.h
@@ -363,18 +363,16 @@ protected:
             float trackTemp = ir_TrackTempCrew.getFloat();
             float airTemp   = ir_AirTemp.getFloat();
             char  tempUnit  = 'C';
-            int lapcount = ir_CarIdxLap.getInt(ir_session.driverCarIdx);
-            int totallaps = ir_SessionLapsTotal.getInt();
 
             if( imperial ) {
                 trackTemp = celsiusToFahrenheit( trackTemp );
                 airTemp   = celsiusToFahrenheit( airTemp );
                 tempUnit  = 'F';
             }
-          
+
             m_brush->SetColor(float4(1,1,1,0.4f));
             m_renderTarget->DrawLine( float2(0,ybottom),float2((float)m_width,ybottom),m_brush.Get() );
-            swprintf( s, _countof(s), L"SoF: %d      Track Temp: %.1f°%c      Air Temp: %.1f°%c      Setup: %s      Subsession: %d      Lap: %d/%d", ir_session.sof, trackTemp, tempUnit, airTemp, tempUnit, ir_session.isFixedSetup?L"fixed":L"open", ir_session.subsessionId, lapcount, totallaps);
+            swprintf( s, _countof(s), L"SoF: %d      Track Temp: %.1f°%c      Air Temp: %.1f°%c      Setup: %s      Subsession: %d", ir_session.sof, trackTemp, tempUnit, airTemp, tempUnit, ir_session.isFixedSetup?L"fixed":L"open", ir_session.subsessionId );
             y = m_height - (m_height-ybottom)/2;
             m_brush->SetColor( headerCol );
             m_text.render( m_renderTarget.Get(), s, m_textFormat.Get(), xoff, (float)m_width-2*xoff, y, m_brush.Get(), DWRITE_TEXT_ALIGNMENT_CENTER );


### PR DESCRIPTION
RPM lights flash yellow if the limiter is enabled. flashes on for half second, off for half second.

I have tested this by reverting `if (!(ir_EngineWarnings.getInt() & irsdk_pitSpeedLimiter))` but have not tested it by enabling the pit limiter in sim. I do not have access to my pc with iRacing installed. Please test that the if statement works when enabling/disabling the limiter in sim. If it doesn't, then OverlayDDU.h line 261 needs looking into. If there are any other issues, I can look into them.